### PR TITLE
공공예약서비스 정보 데이터베이스 구축 배치 프로세싱 개발 완료

### DIFF
--- a/src/main/java/com/example/lionproject/Batch/Tasklet/FetchLastUpdatedTasklet.java
+++ b/src/main/java/com/example/lionproject/Batch/Tasklet/FetchLastUpdatedTasklet.java
@@ -1,0 +1,52 @@
+package com.example.lionproject.Batch.Tasklet;
+
+import com.example.lionproject.domain.seoulApi.PublicReservationLastUpdated;
+import com.example.lionproject.domain.seoulApi.enums.PublicReservationType;
+import com.example.lionproject.repository.seoulApi.PublicReservationLastUpdatedRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FetchLastUpdatedTasklet implements Tasklet {
+
+    private final PublicReservationLastUpdatedRepository repository;
+    private boolean updatedToday = false;
+    private LocalDate today = LocalDate.now();
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        PublicReservationLastUpdated publicReservationLastUpdated = repository.findFirstByPublicReservationTypeOrderByLastUpdatedDesc(PublicReservationType.GENERAL)
+                .orElseGet(() -> PublicReservationLastUpdated.of(0L, PublicReservationType.GENERAL, LocalDate.MIN));
+        LocalDate lastUpdated = publicReservationLastUpdated.getLastUpdated();
+
+        if(lastUpdated.equals(today)){
+            log.info("[FetchLastUpdatedTasklet] [lastUpdated == today] Already updated for today.");
+            contribution.setExitStatus(ExitStatus.COMPLETED);
+            return RepeatStatus.FINISHED;
+        }
+        if(updatedToday){
+            log.info("[FetchLastUpdatedTasklet] [updatedToday == true] Already updated for today.");
+            repository.saveAndFlush(PublicReservationLastUpdated.of(PublicReservationType.GENERAL, today));
+
+            contribution.setExitStatus(ExitStatus.COMPLETED);
+            return RepeatStatus.FINISHED;
+        }
+
+        updatedToday = true;
+        contribution.setExitStatus(new ExitStatus("CONTINUABLE"));
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/example/lionproject/domain/dto/WebClientDTO.java
+++ b/src/main/java/com/example/lionproject/domain/dto/WebClientDTO.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Data
-@ToString(of = {"serviceId"})
 @NoArgsConstructor
 @AllArgsConstructor
 public class WebClientDTO {
@@ -87,8 +86,8 @@ public class WebClientDTO {
         @JsonProperty("X")
         private String x;
 
-        @JsonProperty("Y")
-        private String Y;
+        @JsonProperty("y")
+        private String y;
 
         @JsonProperty("SVCOPNBGNDT")
         private String svcOpnBgnDt;
@@ -134,8 +133,8 @@ public class WebClientDTO {
     public List<PublicServiceReservationDto> toDto() {
         return this.publicServiceReservation.rows.stream()
                 .map(r -> PublicServiceReservationDto.of(
-                        r.div, r.service, r.gubun, r.serviceId, r.maxClassNM, r.minClassNM, r.svcStatNM, r.svcNM, r.payAtNM, r.placeNM, r.useTgtInfo, "r.svcUrl",
-                        r.x, r.y, r.svcOpnBgnDt, r.svcOpnEndDt, r.rcptbgndt, r.rcptenddt, r.areaNM, "r.imgUrl", "r.dtlCont", r.telNo, r.vMin, r.vMax, r.revStdDayNM, r.RevStdDay
+                        r.div, r.service, r.gubun, r.serviceId, r.maxClassNM, r.minClassNM, r.svcStatNM, r.svcNM, r.payAtNM, r.placeNM, r.useTgtInfo, r.svcUrl,
+                        r.x, r.y, r.svcOpnBgnDt, r.svcOpnEndDt, r.rcptbgndt, r.rcptenddt, r.areaNM, r.imgUrl, r.dtlCont, r.telNo, r.vMin, r.vMax, r.revStdDayNM, r.RevStdDay
                 )).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/example/lionproject/domain/dto/WebClientDTO.java
+++ b/src/main/java/com/example/lionproject/domain/dto/WebClientDTO.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
+@ToString(of = {"serviceId"})
 @NoArgsConstructor
 @AllArgsConstructor
 public class WebClientDTO {
@@ -48,7 +51,7 @@ public class WebClientDTO {
         @JsonProperty("DIV")
         private String div;
 
-        @JsonProperty("Service")
+        @JsonProperty("SERVICE")
         private String service;
 
         @JsonProperty("GUBUN")
@@ -122,6 +125,18 @@ public class WebClientDTO {
 
         @JsonProperty("REVSTDDAY")
         private String RevStdDay;
+    }
+
+    public int fetchListTotalCount() {
+        return Integer.parseInt(this.publicServiceReservation.listTotalCount);
+    }
+
+    public List<PublicServiceReservationDto> toDto() {
+        return this.publicServiceReservation.rows.stream()
+                .map(r -> PublicServiceReservationDto.of(
+                        r.div, r.service, r.gubun, r.serviceId, r.maxClassNM, r.minClassNM, r.svcStatNM, r.svcNM, r.payAtNM, r.placeNM, r.useTgtInfo, "r.svcUrl",
+                        r.x, r.y, r.svcOpnBgnDt, r.svcOpnEndDt, r.rcptbgndt, r.rcptenddt, r.areaNM, "r.imgUrl", "r.dtlCont", r.telNo, r.vMin, r.vMax, r.revStdDayNM, r.RevStdDay
+                )).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/example/lionproject/domain/entity/PublicServiceReservation.java
+++ b/src/main/java/com/example/lionproject/domain/entity/PublicServiceReservation.java
@@ -86,7 +86,7 @@ public class PublicServiceReservation {
                 rcptenddt,
                 areaNM,
                 imgUrl,
-                dtlCont,
+                "Check Web Page",
                 telNo,
                 vMin,
                 vMax

--- a/src/main/java/com/example/lionproject/domain/seoulApi/PublicReservationLastUpdated.java
+++ b/src/main/java/com/example/lionproject/domain/seoulApi/PublicReservationLastUpdated.java
@@ -1,0 +1,34 @@
+package com.example.lionproject.domain.seoulApi;
+
+import com.example.lionproject.domain.seoulApi.enums.PublicReservationType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PublicReservationLastUpdated {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private PublicReservationType publicReservationType;
+
+    private LocalDate lastUpdated;
+
+    public static PublicReservationLastUpdated of(Long id, PublicReservationType publicReservationType, LocalDate lastUpdated) {
+        return new PublicReservationLastUpdated(id, publicReservationType, lastUpdated);
+    }
+    public static PublicReservationLastUpdated of(PublicReservationType publicReservationType, LocalDate lastUpdated) {
+        return PublicReservationLastUpdated.of(null, publicReservationType, lastUpdated);
+    }
+}

--- a/src/main/java/com/example/lionproject/domain/seoulApi/enums/PublicReservationType.java
+++ b/src/main/java/com/example/lionproject/domain/seoulApi/enums/PublicReservationType.java
@@ -1,0 +1,5 @@
+package com.example.lionproject.domain.seoulApi.enums;
+
+public enum PublicReservationType {
+    GENERAL, EDUCATION, MEDICAL
+}

--- a/src/main/java/com/example/lionproject/repository/seoulApi/PublicReservationLastUpdatedRepository.java
+++ b/src/main/java/com/example/lionproject/repository/seoulApi/PublicReservationLastUpdatedRepository.java
@@ -1,0 +1,12 @@
+package com.example.lionproject.repository.seoulApi;
+
+import com.example.lionproject.domain.seoulApi.PublicReservationLastUpdated;
+import com.example.lionproject.domain.seoulApi.enums.PublicReservationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PublicReservationLastUpdatedRepository extends JpaRepository<PublicReservationLastUpdated, Long> {
+
+    Optional<PublicReservationLastUpdated> findFirstByPublicReservationTypeOrderByLastUpdatedDesc(PublicReservationType type);
+}

--- a/src/test/java/com/example/lionproject/repository/seoulApi/PublicReservationLastUpdatedRepositoryTest.java
+++ b/src/test/java/com/example/lionproject/repository/seoulApi/PublicReservationLastUpdatedRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.example.lionproject.repository.seoulApi;
+
+import com.example.lionproject.domain.seoulApi.PublicReservationLastUpdated;
+import com.example.lionproject.domain.seoulApi.enums.PublicReservationType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest
+class PublicReservationLastUpdatedRepositoryTest {
+
+    @Autowired
+    private PublicReservationLastUpdatedRepository repository;
+
+    @Test
+    void givenTestData_whenCallingOrderByLastUpdatedDesc_thenSuccess() throws Exception {
+        // Given
+        final int size = 5;
+        List<PublicReservationLastUpdated> testData = createTestData(size);
+        repository.saveAllAndFlush(testData);
+
+        LocalDate today = LocalDate.now();
+        LocalDate lastDate = today.plusDays(size);
+
+        // When
+        PublicReservationLastUpdated result = repository.findFirstByPublicReservationTypeOrderByLastUpdatedDesc(PublicReservationType.GENERAL)
+                .orElseGet(() -> PublicReservationLastUpdated.of(0L, PublicReservationType.GENERAL, today));
+        System.out.println("result = " + result);
+
+        // Then
+        Assertions.assertThat(result.getLastUpdated()).isEqualTo(lastDate);
+    }
+
+    public static List<PublicReservationLastUpdated> createTestData(int size) {
+        LocalDate today = LocalDate.now();
+        List<PublicReservationLastUpdated> data = new ArrayList<>();
+        for(int i = 1; i <= size; i++){
+            data.add(PublicReservationLastUpdated.of(
+                    (long) i, PublicReservationType.GENERAL, today.plusDays(i)));
+        }
+
+        return data;
+    }
+
+
+}


### PR DESCRIPTION
* 공공예약서비스를 하루에 한번씩만 업데이트 할 수 있도록 개발
* 데이터베이스에 중복된 데이터가 있으면 업데이트가 안되도록 개발